### PR TITLE
Pattern variation on the basis of our conversation

### DIFF
--- a/CombineTest/ContentView.swift
+++ b/CombineTest/ContentView.swift
@@ -7,18 +7,18 @@ struct ContentViewImpl: View {
   
   init(presenter: Presenter) {
     self.presenter = presenter
-    presenter.start()
+    presenter.start2()
   }
   
   var body: some View {
     VStack {
       HStack {
-        Text("COMPOSITE showcases the view model resulting from two separate publishers, each operating on a different background thread and providing a UseCaseState holding a different domain model. The publishers outputs are then combined in the Presenter, sync'ed on main, and their output (UseCaseStates) fed to a statehandler. \n\nSTREAM 1 and STREAM 2 display the models published on those discrete streams")
+        Text("COMPOSITE showcases the view model resulting from two separate publishers, each operating on a different background thread and providing a UseCaseState holding a different domain model. The publishers outputs are then combined in the Presenter, sync'ed on main, and their output (UseCaseStates) fed to a statehandler.")
       }.padding()
       VStack(alignment: .leading, spacing: 14) {
       Text("Composite = \(presenter.compositeModel.name)")
-      Text("Stream 1️⃣ = \(presenter.modelOne.name)")
-      Text("Stream 2️⃣  = \(presenter.modelTwo.name)")
+      //Text("Stream 1️⃣ = \(presenter.modelOne.name)")
+     // Text("Stream 2️⃣  = \(presenter.modelTwo.name)")
     }
     .padding()
   }

--- a/CombineTest/Presenter.swift
+++ b/CombineTest/Presenter.swift
@@ -4,90 +4,83 @@ import SwiftUI
 
 class Presenter: ObservableObject {
   
-  private let useCaseOne: UseCaseOne
-  private let useCaseTwo: UseCaseTwo
-  @Published var compositeModel: ViewModelItem = ViewModelItem(name: "")
-  private var cancellables = Set<AnyCancellable>()
-  
-  private lazy var actions = StatesHandler.Actions<DomainModelOne, DomainModelTwo>(
-    onLoading: {
-      self.compositeModel = ViewModelItem(name: "Loading ⌛")
-    },
-    onSuccess: { model1, model2 in
-      self.compositeModel = ViewModelItem(name: "🎉 1️⃣ \(model1.name) 2️⃣ \(String(model2.number))")
-    },
-    onError: { _ in
-      self.compositeModel = ViewModelItem(name: "Failure ❌")
-    })
- 
   init(useCaseOne: UseCaseOne,
        useCaseTwo: UseCaseTwo) {
     self.useCaseOne = useCaseOne
     self.useCaseTwo = useCaseTwo
   }
   
-  func start() {
+  private let useCaseOne: UseCaseOne
+  private let useCaseTwo: UseCaseTwo
+  @Published var compositeModel: ViewModelItem = ViewModelItem(name: "")
+  private var cancellables = Set<AnyCancellable>()
+  
+  private var state1: UseCaseState<DomainModelOne> = .noValue
+  private var state2: UseCaseState<DomainModelTwo> = .noValue
+  private var receivedError: Error?
+  
+  lazy var onCompletion: ((Subscribers.Completion<Error>) -> Void)? = { [weak self] completion in
+      switch completion {
+      case .finished:
+       break
+      case .failure(let error):
+        self?.receivedError = error
+        self?.makeViewModel()
+      }
+  }
+  
+  func start1() {
     useCaseOne.start()
     useCaseTwo.start()
     
-    startObservingComposite()
-    startObservingState1()
-    startObservingState2()
+    useCaseOne.caseState
+      .receive(on: DispatchQueue.main)
+      .sink(receiveCompletion: { [weak self] error in
+              self?.onCompletion?(error) },
+            receiveValue: { [weak self] state in
+              self?.state1 = state
+              self?.makeViewModel()})
+      .store(in: &cancellables)
+    
+    useCaseTwo.caseState
+      .receive(on: DispatchQueue.main)
+      .sink(receiveCompletion: { [weak self] error in
+              self?.onCompletion?(error) },
+            receiveValue: { [weak self] state in
+              self?.state2 = state
+              self?.makeViewModel()})
+      .store(in: &cancellables)
   }
   
-  func startObservingComposite()  {
+  // ALTERNATIVE PATTERN USING CombineLatest
+  func start2()  {
+    useCaseOne.start()
+    useCaseTwo.start()
+    
     Publishers
       .CombineLatest(useCaseOne.caseState.receive(on: DispatchQueue.main),
                      useCaseTwo.caseState.receive(on: DispatchQueue.main))
-      .sink(receiveValue: { [weak self] state1, state2 in
-        guard let self = self else { return }
-        
-        StatesHandler.handle(state1: state1,
-                             state2: state2,
-                             actions: self.actions)
+      .sink(receiveCompletion: { [weak self] error in
+        self?.onCompletion?(error)
+      },
+      receiveValue: { [weak self] state1, state2 in
+        self?.state1 = state1
+        self?.state2 = state2
+        self?.makeViewModel()
       })
       .store(in: &cancellables)
   }
   
-  // Everything below is here only for the sake of the demo allowing the ui to showcase the work of the state handler vs the two independent streams. Our typical Presenter class would finish here.
-  
-  @Published var modelOne: ViewModelItem = ViewModelItem(name: "")
-  @Published var modelTwo: ViewModelItem = ViewModelItem(name: "")
-  
-  func startObservingState1() {
-    useCaseOne.caseState
-      .receive(on: DispatchQueue.main)
-      .sink(receiveValue: { [weak self] state1 in
-      guard let self = self else { return }
-      self.modelOne = ViewModelItem(name: "\(state1.printValue)")
-    })
-    .store(in: &cancellables)
-  }
-  
-  func startObservingState2() {
-    useCaseTwo.caseState
-      .receive(on: DispatchQueue.main)
-      .sink(receiveValue: { [weak self] state2 in
-      guard let self = self else { return }
-      self.modelTwo = ViewModelItem(name: "\(state2.printValue)")
-    })
-    .store(in: &cancellables)
-  }
-}
-
-// This extension is purely for the sake of demo
-extension UseCaseState {
-  var printValue: String {
-    switch self {
-    case .idle:
-      return "Idle 💤"
-    case .loading:
-      return "Loading ⌛"
-    case let .success(value):
-      return String("🎉 \(value)")
-    case .failure:
-      return "Failure ❌"
+  private func makeViewModel() {
+    switch (state1, state2, receivedError) {
+      case (_, _, let error) where error != nil:
+        compositeModel = ViewModelItem(name: "Failure: \(error.debugDescription)")
+    case (.loading, _, _), (_, .loading, _):
+      compositeModel = ViewModelItem(name: "Loading ⌛")
+    case let (.loaded(value1), .loaded(value2), _):
+      compositeModel = ViewModelItem(name: String("🎉 \(value1) + \(value2)"))
+    default:
+      break
     }
   }
 }
-

--- a/CombineTest/Presenter.swift
+++ b/CombineTest/Presenter.swift
@@ -65,7 +65,7 @@ class Presenter: ObservableObject {
     }
   }
   
-  // ALTERNATIVE PATTERN USING CombineLatest and StateHandler
+  // ALTERNATIVE PATTERN USING CombineLatest
   
   lazy var onCompletion2: ((Subscribers.Completion<Error>) -> Void)? = { [weak self] completion in
       switch completion {

--- a/CombineTest/Presenter.swift
+++ b/CombineTest/Presenter.swift
@@ -52,25 +52,6 @@ class Presenter: ObservableObject {
       .store(in: &cancellables)
   }
   
-  // ALTERNATIVE PATTERN USING CombineLatest
-  func start2()  {
-    useCaseOne.start()
-    useCaseTwo.start()
-    
-    Publishers
-      .CombineLatest(useCaseOne.caseState.receive(on: DispatchQueue.main),
-                     useCaseTwo.caseState.receive(on: DispatchQueue.main))
-      .sink(receiveCompletion: { [weak self] error in
-        self?.onCompletion?(error)
-      },
-      receiveValue: { [weak self] state1, state2 in
-        self?.state1 = state1
-        self?.state2 = state2
-        self?.makeViewModel()
-      })
-      .store(in: &cancellables)
-  }
-  
   private func makeViewModel() {
     switch (state1, state2, receivedError) {
       case (_, _, let error) where error != nil:
@@ -82,5 +63,51 @@ class Presenter: ObservableObject {
     default:
       break
     }
+  }
+  
+  // ALTERNATIVE PATTERN USING CombineLatest and StateHandler
+  
+  private lazy var actions = StatesHandler.Actions<DomainModelOne, DomainModelTwo>(
+    onLoading: {
+      self.compositeModel = ViewModelItem(name: "Loading ⌛")
+    },
+    onSuccess: { model1, model2 in
+      self.compositeModel = ViewModelItem(name: "🎉 1️⃣ \(model1.name) 2️⃣ \(String(model2.number))")
+    },
+    onError: { _ in
+      self.compositeModel = ViewModelItem(name: "Failure ❌")
+    })
+  
+  lazy var onCompletion2: ((Subscribers.Completion<Error>) -> Void)? = { [weak self] completion in
+      switch completion {
+      case .finished:
+       break
+      case .failure(let error):
+        guard let self = self else { return }
+        StatesHandler.handle(state1: nil,
+                             state2: nil,
+                             error: error,
+                             actions: self.actions)
+      }
+  }
+  
+  func start2()  {
+    useCaseOne.start()
+    useCaseTwo.start()
+    
+    Publishers
+      .CombineLatest(useCaseOne.caseState.receive(on: DispatchQueue.main),
+                     useCaseTwo.caseState.receive(on: DispatchQueue.main))
+      .sink(receiveCompletion: { [weak self] error in
+        self?.onCompletion2?(error)
+      },
+      receiveValue: { [weak self] state1, state2 in
+        guard let self = self else { return }
+        StatesHandler.handle(state1: state1,
+                             state2: state2,
+                             error: nil,
+                             actions: self.actions)
+      })
+      .store(in: &cancellables)
   }
 }

--- a/CombineTest/StateHandler.swift
+++ b/CombineTest/StateHandler.swift
@@ -1,39 +1,39 @@
-// This associates states and actions and can be expanded to handle 2, 3, 4 use cases, pairing up with CombineLatest, CombineLatest2, CombineLatest3 operators in the Presenter.
-enum StatesHandler {
-  
-  struct Actions<T, S> {
-    let onLoading: () -> Void
-    let onSuccess: (T, S) -> Void
-    let onError: (Error) -> Void
-  }
-  
-  struct Actions3<T, S, U> {
-    let onLoading: () -> Void
-    let onSuccess: (T, S, U) -> Void
-    let onError: (Error) -> Void 
-  }
-  
-  static func handle<T, S>(
-    state1: UseCaseState<T>,
-    state2: UseCaseState<S>,
-    actions: Actions<T, S>) {
-    
-    
-    
-    switch (state1, state2) {
-    
-    case let (.failure(error), _), let (_, .failure(error)):
-      actions.onError(error)
-    
-    case (_, .loading), (.loading, _):
-      actions.onLoading()
-      
-    case let (.success(value1), .success(value2)):
-      actions.onSuccess(value1, value2)
-      
-    default:
-      break
-    }
-  }
-}
+//// This associates states and actions and can be expanded to handle 2, 3, 4 use cases, pairing up with CombineLatest, CombineLatest2, CombineLatest3 operators in the Presenter.
+//enum StatesHandler {
+//  
+//  struct Actions<T, S> {
+//    let onLoading: () -> Void
+//    let onSuccess: (T, S) -> Void
+//    let onError: (Error) -> Void
+//  }
+//  
+//  struct Actions3<T, S, U> {
+//    let onLoading: () -> Void
+//    let onSuccess: (T, S, U) -> Void
+//    let onError: (Error) -> Void 
+//  }
+//  
+//  static func handle<T, S>(
+//    state1: UseCaseState<T>,
+//    state2: UseCaseState<S>,
+//    actions: Actions<T, S>) {
+//    
+//    
+//    
+//    switch (state1, state2) {
+//    
+////    case let (.failure(error), _), let (_, .failure(error)):
+////      actions.onError(error)
+//    
+//    case (_, .loading), (.loading, _):
+//      actions.onLoading()
+//      
+//    case let (.loaded(value1), .loaded(value2)):
+//      actions.onSuccess(value1, value2)
+//      
+//    default:
+//      break
+//    }
+//  }
+//}
 

--- a/CombineTest/StateHandler.swift
+++ b/CombineTest/StateHandler.swift
@@ -1,39 +1,34 @@
-//// This associates states and actions and can be expanded to handle 2, 3, 4 use cases, pairing up with CombineLatest, CombineLatest2, CombineLatest3 operators in the Presenter.
-//enum StatesHandler {
-//  
-//  struct Actions<T, S> {
-//    let onLoading: () -> Void
-//    let onSuccess: (T, S) -> Void
-//    let onError: (Error) -> Void
-//  }
-//  
-//  struct Actions3<T, S, U> {
-//    let onLoading: () -> Void
-//    let onSuccess: (T, S, U) -> Void
-//    let onError: (Error) -> Void 
-//  }
-//  
-//  static func handle<T, S>(
-//    state1: UseCaseState<T>,
-//    state2: UseCaseState<S>,
-//    actions: Actions<T, S>) {
-//    
-//    
-//    
-//    switch (state1, state2) {
-//    
-////    case let (.failure(error), _), let (_, .failure(error)):
-////      actions.onError(error)
-//    
-//    case (_, .loading), (.loading, _):
-//      actions.onLoading()
-//      
-//    case let (.loaded(value1), .loaded(value2)):
-//      actions.onSuccess(value1, value2)
-//      
-//    default:
-//      break
-//    }
-//  }
-//}
+// This associates states and actions and can be expanded to handle 2, 3, 4 use cases, pairing up with CombineLatest, CombineLatest2, CombineLatest3 operators in the Presenter.
+enum StatesHandler {
+  
+  struct Actions<T, S> {
+    let onLoading: () -> Void
+    let onSuccess: (T, S) -> Void
+    let onError: (Error) -> Void
+  }
+  
+  struct Actions3<T, S, U> {
+    let onLoading: () -> Void
+    let onSuccess: (T, S, U) -> Void
+    let onError: (Error) -> Void 
+  }
+  
+  static func handle<T, S>(
+    state1: UseCaseState<T>?,
+    state2: UseCaseState<S>?,
+    error: Error?,
+    actions: Actions<T, S>) {
+    
+    switch (state1, state2, error) {
+      case (_, _, let error) where error != nil:
+        actions.onError(error!)
+    case (.loading, _, _), (_, .loading, _):
+      actions.onLoading()
+    case let (.loaded(value1), .loaded(value2), _):
+      actions.onSuccess(value1, value2)
+    default:
+      break
+    }
+  }
+}
 

--- a/CombineTest/UseCaseState.swift
+++ b/CombineTest/UseCaseState.swift
@@ -4,8 +4,7 @@ import UIKit
 import Combine
 
 enum UseCaseState<Value> {
-  case idle
+  case noValue
   case loading
-  case success(_ value: Value)
-  case failure(_ error: Error)
+  case loaded(_ value: Value)
 }

--- a/CombineTest/UseCaseTwo.swift
+++ b/CombineTest/UseCaseTwo.swift
@@ -2,22 +2,22 @@ import Combine
 import Foundation
 
 protocol UseCaseTwo {
-  var caseState: AnyPublisher<UseCaseState<DomainModelTwo>, Never> { get }
+  var caseState: AnyPublisher<UseCaseState<DomainModelTwo>, Error> { get }
   func start()
 }
 
 class UseCaseTwoImpl: UseCaseTwo {
   
   private var timer1: Timer?
-  private let internalState = CurrentValueSubject<UseCaseState<DomainModelTwo>, Never>(.idle)
+  private let internalState = CurrentValueSubject<UseCaseState<DomainModelTwo>, Error>(.noValue)
   
-  var caseState: AnyPublisher<UseCaseState<DomainModelTwo>, Never>{
+  var caseState: AnyPublisher<UseCaseState<DomainModelTwo>, Error>{
     internalState.eraseToAnyPublisher()
   }
   
   func start() {
     internalState.value = .loading
-    timer1 = Timer.scheduledTimer(withTimeInterval: 8, repeats: true) { [weak self] _ in
+    timer1 = Timer.scheduledTimer(withTimeInterval: 6, repeats: true) { [weak self] _ in
       DispatchQueue.global(qos: .userInitiated).async {
       self?.generateRandomInt()
       }
@@ -26,7 +26,7 @@ class UseCaseTwoImpl: UseCaseTwo {
    
   @objc private func generateRandomInt() {
     let int = Array(1...10).randomElement()!
-    internalState.send(.success(DomainModelTwo(number: int)))
+    internalState.send(.loaded(DomainModelTwo(number: int)))
   }
 }
 


### PR DESCRIPTION
Modified `UseCaseState` to exclude Error - now handled by Combine as suggested.
Modified subscribers patterns in Presenter.
I tested 2 possible patterns: `start1()` and `start2()` functions.

As for pattern1 - `start1()` I tried to follow your advice.
Lines 18-20 of `Presenter` are the only way I found to store latest values and error out of sink closures so that the viewModel() function could see them. Is there any less clumsy/more elegant way to do that? 

Pattern2 keeps using `CombineLatest` as a way to see both results (or UseCaseStates) together. You suggested a `map { result 1, result2 -> ViewModel in ... ` but I wasn't able to find a Publisher.map to work like this in this context. Plus the CombineLatest seems to do what we need - unless I am missing something? 